### PR TITLE
Add project and topic flag

### DIFF
--- a/pkg/cmd/publish.go
+++ b/pkg/cmd/publish.go
@@ -13,6 +13,11 @@ import (
 	"github.com/wantedly/pubsub-dead-letter-log/pkg/publisher"
 )
 
+var publishOption = struct {
+	project string
+	topic   string
+}{}
+
 func newPublishCommand() *cobra.Command {
 	c := cobra.Command{
 		Use:          "publish",
@@ -33,7 +38,17 @@ func newPublishCommand() *cobra.Command {
 			})
 
 			for _, log := range logs {
-				p, err := publisher.New(ctx, log.Project, log.Topic)
+				project := publishOption.project
+				if project == "" {
+					project = log.Project
+				}
+
+				topic := publishOption.topic
+				if topic == "" {
+					topic = log.Topic
+				}
+
+				p, err := publisher.New(ctx, project, topic)
 				if err != nil {
 					return errors.WithStack(err)
 				}
@@ -50,5 +65,7 @@ func newPublishCommand() *cobra.Command {
 			return errors.WithStack(publisher.Close())
 		},
 	}
+	c.Flags().StringVar(&publishOption.project, "project", "", "pubsub project name. If not set, publish to the original project described in the dead-letter log.")
+	c.Flags().StringVar(&publishOption.topic, "topic", "", "pubsub topic name. If not set, publish to the original topic described in the dead-letter log.")
 	return &c
 }


### PR DESCRIPTION
## Why

To overwrite publishing topic by command line.

## What

Accept `project` and `topic` flags.

```console
$ psdll publish -h
publish messages to Google Cloud Pub/Sub

Usage:
  psdll publish [flags]

Flags:
  -h, --help             help for publish
      --project string   pubsub project name. If not set, publish to the original project described in the dead-letter log.
      --topic string     pubsub topic name. If not set, publish to the original topic described in the dead-letter log.
```