### PR TITLE
Improve help message

### DIFF
--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -15,10 +15,11 @@ import (
 
 func newListCommand() *cobra.Command {
 	c := cobra.Command{
-		Use:          "list",
-		Short:        "list log files from URL",
-		SilenceUsage: true,
-		RunE: func(_ *cobra.Command, args []string) error {
+		Use:   "list",
+		Short: "list log files from URL",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			ctx := context.Background()
 			var logs []psdll.DeadLetterLog
 			for _, arg := range args {

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -15,7 +15,7 @@ import (
 
 func newListCommand() *cobra.Command {
 	c := cobra.Command{
-		Use:   "list",
+		Use:   "list <url> ...",
 		Short: "list log files from URL",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/publish.go
+++ b/pkg/cmd/publish.go
@@ -21,10 +21,11 @@ var publishOption = struct {
 
 func newPublishCommand() *cobra.Command {
 	c := cobra.Command{
-		Use:          "publish",
-		Short:        "publish messages to Google Cloud Pub/Sub",
-		SilenceUsage: true,
-		RunE: func(_ *cobra.Command, args []string) error {
+		Use:   "publish",
+		Short: "publish messages to Google Cloud Pub/Sub",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			ctx := context.Background()
 			var logs []psdll.DeadLetterLog
 			for _, arg := range args {

--- a/pkg/cmd/publish.go
+++ b/pkg/cmd/publish.go
@@ -21,7 +21,7 @@ var publishOption = struct {
 
 func newPublishCommand() *cobra.Command {
 	c := cobra.Command{
-		Use:   "publish",
+		Use:   "publish <url> ...",
 		Short: "publish messages to Google Cloud Pub/Sub",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Why

`publish` and `list` command require least one URLs which has log files. Although, without any args, these commands successes and return nothing.

## What

- set minimum args
- tweak use line

#### demo

```console
$ psdll list
Error: requires at least 1 arg(s), only received 0
Usage:
  psdll list <url> ... [flags]

Flags:
  -h, --help   help for list

requires at least 1 arg(s), only received 0
```